### PR TITLE
フロントからAPI叩かれた際、Request header field access-control-allow-origin is no…

### DIFF
--- a/unityapi/settings.py
+++ b/unityapi/settings.py
@@ -21,6 +21,19 @@ DEBUG = env.bool('DEBUG', default=False)
 ALLOWED_HOSTS = env.list('ALLOWED_HOSTS', default=[])
 CORS_ORIGIN_WHITELIST = env.list('CORS_ORIGIN_WHITELIST', default=[])
 
+CORS_ALLOW_HEADERS = (
+    'accept',
+    'accept-encoding',
+    'authorization',
+    'content-type',
+    'dnt',
+    'origin',
+    'user-agent',
+    'x-csrftoken',
+    'x-requested-with',
+    'access-control-allow-origin',
+)
+
 # 本番環境用
 # LOGGING = {
 #     "version": 1,


### PR DESCRIPTION
…t allowed by Access-Control-Allow-Headers in preflight responseとなる

フロント(Vue)からAPI叩くと以下エラーが返ってくるため修正

```
Access to XMLHttpRequest at 'https://unity-backend.temona.co.jp/authen/jwt/create' from origin 'http://localhost:3000' has been blocked by CORS policy: Request header field access-control-allow-origin is not allowed by Access-Control-Allow-Headers in preflight response
```