### PR TITLE
[カオナビ]自己紹介シートの更新時にカオナビから400が返却される問題

### DIFF
--- a/basicapi/lib/kaonavi/connector.py
+++ b/basicapi/lib/kaonavi/connector.py
@@ -9,7 +9,6 @@ from .user_filter import UserFilter as KaonaviUserFilter
 END_POINT_URL_BASE = 'https://api.kaonavi.jp/api/v2.0'
 SELF_INTRO_SHEET_ID = 20
 NONE_AS_DEFAULT_VALUE = None
-NAME_FIELD_ID = 284
 BIRTH_PLACE_FIELD_ID = 286
 JOB_DESCRIPTION_FIELD_ID = 287
 CAREER_FIELD_ID = 288
@@ -209,7 +208,6 @@ class KaonaviConnector:
                     "records": [
                         {
                             "custom_fields": [
-                                {"id": NAME_FIELD_ID, "values": [user.username]},
                                 {"id": BIRTH_PLACE_FIELD_ID, "values": [params['birth_place']]},
                                 {"id": JOB_DESCRIPTION_FIELD_ID, "values": [params['job_description']]},
                                 {"id": CAREER_FIELD_ID, "values": [params['career']]},

--- a/basicapi/lib/kaonavi/connector.py
+++ b/basicapi/lib/kaonavi/connector.py
@@ -198,7 +198,8 @@ class KaonaviConnector:
         if response.ok:
             return ApiResult(success=True)
         else:
-            return ApiResult(success=False)
+            errors = response.json()['errors']
+            return ApiResult(success=False, errors=errors)
 
     def build_self_introduction_json(self, user, params):
         obj = {

--- a/basicapi/views.py
+++ b/basicapi/views.py
@@ -43,11 +43,11 @@ class UserView(APIView):
         params = request.data
         response = KaonaviConnector().create_or_update_self_introduction_info(user, params['contents'])
 
-        if response.is_success:
+        if response.is_success():
             data = dict(user_id=user.id, success=True)
             return Response(data, status=status.HTTP_200_OK)
         else:
-            data = dict(user_id=user.id, success=False, errors=['データの更新/保存に失敗しました'])
+            data = dict(user_id=user.id, success=False, errors=response.errors)
             return Response(data, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
 class ProfileViewSet(ModelViewSet):


### PR DESCRIPTION
カオナビ上の自己紹介シートを更新時(PATCH /api/users/:user_id)カオナビから400が返却される
原因
元々自己紹介シートには社員の名前を入力する項目があり、その項目のidが284だった
それも更新できるようにカオナビ側にid:284のパラメータを送っていたが、気づいたらその項目がなくなっていた。

おそらく人事が削除してた。

```python
(Pdb)
<Response [400]>
(Pdb) response.json()
{'errors': ['社員番号:"0224"の指定されたシート項目（id:284）が存在しません。レイアウト設定APIを実行してIDをご確認ください。']}
```